### PR TITLE
Monterey doesn't support CGSession

### DIFF
--- a/Lock.app/Contents/MacOS/main.command
+++ b/Lock.app/Contents/MacOS/main.command
@@ -10,11 +10,11 @@ FILEPATH=$(dirname "$0")
 BASEPATH=${FILEPATH%/*/*/*}
 echo "$BASEPATH"
 
-CGSESSION_PATH='(-lh "/System/Library/CoreServices/\"Menu Extras\"/User.menu/Contents/Resources/CGSession")'
+SLEEP_CMD='pmset'
 
 if [ -f "$FILE" ]; then
-  # Susspend session with CGSession
-  "${CGSESSION_PATH}" -suspend
+  # Susspend session with pmset
+  "${SLEEP_CMD}" sleepnow
 else
   # Susspend session by keystrokes through osascript
   osascript -e 'tell application "System Events" to keystroke "q" using {command down,control down}'


### PR DESCRIPTION
CGSession went away in Monterey. Alternatively, `pmset sleepnow` puts the machine to sleep which is actually what I personally tend to prefer when walking away from the machine. `pmset displaysleepnow` is also an alternative.